### PR TITLE
chore: enable Renovate security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
       "matchJsonata": [
         "$exists(vulnerabilityFixVersion)"
       ],
-      "labels": [
+      "addLabels": [
         "security"
       ],
       "automerge": false
@@ -40,7 +40,7 @@
   ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "labels": [
+    "addLabels": [
       "security"
     ],
     "automerge": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    "group:allNonMajor"
+    "group:allNonMajor",
+    ":enableVulnerabilityAlerts"
   ],
   "labels": [
     "Meta: Dependencies"
@@ -20,6 +21,29 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    },
+    {
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion)"
+      ],
+      "labels": [
+        "security"
+      ],
+      "automerge": false
     }
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ],
+    "automerge": false,
+    "vulnerabilityFixStrategy": "lowest"
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
       "addLabels": [
         "security"
       ],
-      "automerge": false
+      "automerge": true
     }
   ],
   "osvVulnerabilityAlerts": true,
@@ -43,7 +43,7 @@
     "addLabels": [
       "security"
     ],
-    "automerge": false,
+    "automerge": true,
     "vulnerabilityFixStrategy": "lowest"
   }
 }


### PR DESCRIPTION
## Summary

- Enables Renovate vulnerability-alert PRs sourced from GitHub Dependabot alerts.
- Enables OSV scanning as a supplemental source for supported direct dependencies.
- Preserves the existing `Meta: Dependencies` label and adds `security` to vulnerability fixes.
- Prefers the lowest patched version.
- Automerges vulnerability fixes after CI succeeds, including major security fixes.
- Keeps ordinary non-security major updates manual.
- Matches the security policy now merged in `turbo.ooo` and `fxp.fi`.

## Validation

- JSON parsing passed.
- `renovate-config-validator` from Renovate 44.26.0 passed.
- `git diff --check` passed.
- GitHub vulnerability-alert access returned HTTP 204.
- Comparison of the normalized security policy against the default-branch configs in `turbo.ooo` and `fxp.fi` matched exactly.
- Repository-level GitHub **Allow auto-merge** is enabled.

## Security sources

- **Primary advisory source:** GitHub Dependabot alerts, consumed by Renovate.
- **Supplemental source:** OSV via `osvVulnerabilityAlerts`.
- Dependabot's separate automated security-update PR generator remains disabled to avoid duplicate PRs.

## Hosted integration

The repository config can be validated locally, but the hosted Mend App path is proven only when it creates a real `app/renovate` security PR carrying both `Meta: Dependencies` and `security`. The Mend organization/repository must remain in Interactive mode and the App must retain `Dependabot alerts: read`.

## Automerge safety

Renovate security automerge is explicitly enabled in both `vulnerabilityAlerts` and the vulnerability-specific package rule. GitHub native auto-merge is enabled for the repository. This repository currently has no branch protection or ruleset requiring checks, so the first generated security PR must be watched to confirm Renovate waits for CI before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling.
  * Security fixes are now prioritized for automatic merging and labeled accordingly.
  * Minor, patch, and pinned updates continue to be auto-merged, while major updates require manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->