### PR TITLE
fix: repair latency monitor application lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ Environment variables:
 
 ```bash
 # Install dependencies
-poetry install
+uv sync
 
 # Run Flask dev server
-poetry run python -m latency_monitor.latency_monitor
+uv run python -m latency_monitor.latency_monitor
 
 # Run Celery worker (separate terminal)
-poetry run celery -A latency_monitor.latency_monitor:celery worker
+uv run celery -A latency_monitor.latency_monitor:celery worker
 
 # Run Celery beat scheduler (separate terminal)
-poetry run celery -A latency_monitor.latency_monitor:celery beat
+uv run celery -A latency_monitor.latency_monitor:celery beat
 
 # Run tests
-poetry run pytest
+uv run pytest
 ```
 
 ## Requirements

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   web:
     image: ghcr.io/turbocheetah/latency-monitor:master
@@ -23,7 +21,7 @@ services:
     image: ghcr.io/turbocheetah/latency-monitor:master
     container_name: latency-monitor-worker
     restart: unless-stopped
-    command: uv run celery -A latency_monitor.latency_monitor.celery worker -B --loglevel=info
+    command: uv run celery -A latency_monitor.latency_monitor:celery worker -B --loglevel=info
     depends_on:
       - redis
     environment:

--- a/latency_monitor/__init__.py
+++ b/latency_monitor/__init__.py
@@ -1,0 +1,16 @@
+"""Latency Monitor application package."""
+
+__all__ = ["App", "app"]
+
+
+def __getattr__(name: str):
+    """Load the application module only when its public objects are requested."""
+    if name == "App":
+        from .latency_monitor import App
+
+        return App
+    if name == "app":
+        from .latency_monitor import app
+
+        return app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/latency_monitor/app_instance.py
+++ b/latency_monitor/app_instance.py
@@ -24,7 +24,7 @@ def get_app() -> App:
     """Return the process-wide application instance."""
     global _app
     if _app is None:
-        from .latency_monitor import App
+        from .latency_monitor import app
 
-        _app = App()
+        _app = app
     return _app

--- a/latency_monitor/app_instance.py
+++ b/latency_monitor/app_instance.py
@@ -1,0 +1,30 @@
+"""Access to the process-wide application instance.
+
+The task and route modules need the same configured App without importing the
+module that registers those modules while it is still being initialised.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .latency_monitor import App
+
+_app: App | None = None
+
+
+def set_app(app: App) -> None:
+    """Register the application instance created during package startup."""
+    global _app
+    _app = app
+
+
+def get_app() -> App:
+    """Return the process-wide application instance."""
+    global _app
+    if _app is None:
+        from .latency_monitor import App
+
+        _app = App()
+    return _app

--- a/latency_monitor/dig.py
+++ b/latency_monitor/dig.py
@@ -23,12 +23,11 @@ def dig(target: str) -> dict:
     cmd = ["dig", "google.com", f"@{target}"]
     try:
         result = run_command(cmd)
-    except RuntimeError as exc:
+        parsed_output = parse_dig(result.stdout)
+    except (RuntimeError, ValueError) as exc:
         error = f"ERROR: {exc}"
         print_task_error("DIG", target, str(exc))
         return {"target": target, "stdout": error, "parsed_output": None}
-
-    parsed_output = parse_dig(result.stdout)
 
     print_dig_result(target, parsed_output)
 

--- a/latency_monitor/dig.py
+++ b/latency_monitor/dig.py
@@ -4,15 +4,18 @@ from os import environ
 
 from influxdb_client import Point
 
-from .latency_monitor import app
+from .app_instance import get_app
 from .utils import parse_dig, print_dig_result, print_task_complete, print_task_start
+
+app = get_app()
 
 
 def dig(target: str) -> dict:
+    """Run a DNS query through one target and return raw and parsed results."""
     print_task_start("DIG", target)
 
     cmd = ["dig", "google.com", f"@{target}"]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     parsed_output = parse_dig(result.stdout)
 
     print_dig_result(target, parsed_output)
@@ -22,7 +25,7 @@ def dig(target: str) -> dict:
 
 @app.celery.task
 def run_dig() -> None:
-    """Run the dig command and update the global variable with the results."""
+    """Run DNS queries for all configured targets and store the results."""
     with ThreadPoolExecutor() as executor:
         results = list(executor.map(dig, app.targets))
 

--- a/latency_monitor/dig.py
+++ b/latency_monitor/dig.py
@@ -1,11 +1,17 @@
-import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from os import environ
 
 from influxdb_client import Point
 
 from .app_instance import get_app
-from .utils import parse_dig, print_dig_result, print_task_complete, print_task_start
+from .utils import (
+    parse_dig,
+    print_dig_result,
+    print_task_complete,
+    print_task_error,
+    print_task_start,
+    run_command,
+)
 
 app = get_app()
 
@@ -15,7 +21,13 @@ def dig(target: str) -> dict:
     print_task_start("DIG", target)
 
     cmd = ["dig", "google.com", f"@{target}"]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        result = run_command(cmd)
+    except RuntimeError as exc:
+        error = f"ERROR: {exc}"
+        print_task_error("DIG", target, str(exc))
+        return {"target": target, "stdout": error, "parsed_output": None}
+
     parsed_output = parse_dig(result.stdout)
 
     print_dig_result(target, parsed_output)
@@ -34,6 +46,9 @@ def run_dig() -> None:
     for res in results:
         target = res["target"]
         app.redis.set(f"dig_{target}", res["stdout"])
+
+        if res["parsed_output"] is None:
+            continue
 
         p = (
             Point("dig")

--- a/latency_monitor/latency_monitor.py
+++ b/latency_monitor/latency_monitor.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 from os import environ
 
 from celery import Celery
@@ -9,7 +10,7 @@ from redis import Redis
 
 
 def parse_crontab(cron_expr: str) -> crontab:
-    """Parse a cron expression (minute hour day_of_month month_of_year day_of_week) into a crontab."""
+    """Parse a five-field cron expression into a Celery crontab schedule."""
     parts = cron_expr.split()
     if len(parts) != 5:
         raise ValueError(f"Invalid cron expression '{cron_expr}': expected 5 fields")
@@ -27,10 +28,12 @@ class App:
         self.flask = Flask(__name__)
 
         schedule = parse_crontab(environ.get("SCHEDULE", "*/5 * * * *"))
+        redis_host = environ.get("REDIS_HOST", "localhost")
+        redis_port = environ.get("REDIS_PORT", "6379")
 
         self.flask.config["CELERY_CONFIG"] = {
-            "broker_url": f"redis://{environ['REDIS_HOST']}:{environ['REDIS_PORT']}/0",
-            "result_backend": f"redis://{environ['REDIS_HOST']}:{environ['REDIS_PORT']}/0",
+            "broker_url": f"redis://{redis_host}:{redis_port}/0",
+            "result_backend": f"redis://{redis_host}:{redis_port}/0",
             "broker_connection_retry_on_startup": True,
             "beat_schedule": {
                 "mtr-task": {
@@ -47,21 +50,24 @@ class App:
         self.celery = Celery(self.flask.name)
         self.celery.conf.update(self.flask.config["CELERY_CONFIG"])
 
-        self.redis = Redis(host=environ["REDIS_HOST"], port=int(environ["REDIS_PORT"]))
+        self.redis = Redis(host=redis_host, port=int(redis_port))
 
         self.influx = InfluxDBClient.from_env_properties()
         self.influx_write_api = self.influx.write_api(write_options=SYNCHRONOUS)
         self.influx_query_api = self.influx.query_api()
 
-        self.targets = environ["TARGETS"].split(",")
+        self.targets = environ.get("TARGETS", "1.1.1.1").split(",")
 
 
 app = App()
 
-# import these so they are actually registered
-from . import routes as _  # noqa
-from . import mtr as _  # noqa
-from . import dig as _  # noqa
+# Register routes and Celery tasks after the singleton is available. These
+# imports are intentionally kept here so every module receives the same App.
+from .app_instance import set_app
+
+set_app(app)
+for module_name in ("dig", "mtr", "routes"):
+    import_module(f"{__package__}.{module_name}")
 
 flask = app.flask
 celery = app.celery

--- a/latency_monitor/latency_monitor.py
+++ b/latency_monitor/latency_monitor.py
@@ -24,7 +24,10 @@ def parse_crontab(cron_expr: str) -> crontab:
 
 
 class App:
+    """Configured Flask, Celery, Redis, and InfluxDB application services."""
+
     def __init__(self) -> None:
+        """Create process-wide services from environment configuration."""
         self.flask = Flask(__name__)
 
         schedule = parse_crontab(environ.get("SCHEDULE", "*/5 * * * *"))

--- a/latency_monitor/mtr.py
+++ b/latency_monitor/mtr.py
@@ -26,12 +26,11 @@ def mtr(target: str) -> dict:
 
     try:
         result = run_command(cmd)
-    except RuntimeError as exc:
+        parsed_output = parse_mtr(result.stdout, target)
+    except (RuntimeError, ValueError) as exc:
         error = f"ERROR: {exc}"
         print_task_error("MTR", target, str(exc))
         return {"target": target, "stdout": error, "parsed_output": None}
-
-    parsed_output = parse_mtr(result.stdout, target)
 
     print_mtr_result(target, parsed_output)
 

--- a/latency_monitor/mtr.py
+++ b/latency_monitor/mtr.py
@@ -1,11 +1,17 @@
-import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from os import environ
 
 from influxdb_client import Point
 
 from .app_instance import get_app
-from .utils import parse_mtr, print_mtr_result, print_task_complete, print_task_start
+from .utils import (
+    parse_mtr,
+    print_mtr_result,
+    print_task_complete,
+    print_task_error,
+    print_task_start,
+    run_command,
+)
 
 app = get_app()
 
@@ -18,7 +24,13 @@ def mtr(target: str) -> dict:
     if ":" in target:
         cmd = ["mtr", "-rwznc", "10", "-6", target]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        result = run_command(cmd)
+    except RuntimeError as exc:
+        error = f"ERROR: {exc}"
+        print_task_error("MTR", target, str(exc))
+        return {"target": target, "stdout": error, "parsed_output": None}
+
     parsed_output = parse_mtr(result.stdout, target)
 
     print_mtr_result(target, parsed_output)
@@ -37,6 +49,9 @@ def run_mtr() -> None:
     for res in results:
         target = res["target"]
         app.redis.set(f"mtr_{target}", res["stdout"])
+
+        if res["parsed_output"] is None:
+            continue
 
         p = (
             Point("mtr")

--- a/latency_monitor/mtr.py
+++ b/latency_monitor/mtr.py
@@ -4,18 +4,21 @@ from os import environ
 
 from influxdb_client import Point
 
-from .latency_monitor import app
+from .app_instance import get_app
 from .utils import parse_mtr, print_mtr_result, print_task_complete, print_task_start
+
+app = get_app()
 
 
 def mtr(target: str) -> dict:
+    """Run MTR for one target and return raw and parsed results."""
     print_task_start("MTR", target)
 
     cmd = ["mtr", "-rwznc", "10", target]
     if ":" in target:
         cmd = ["mtr", "-rwznc", "10", "-6", target]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     parsed_output = parse_mtr(result.stdout, target)
 
     print_mtr_result(target, parsed_output)
@@ -25,7 +28,7 @@ def mtr(target: str) -> dict:
 
 @app.celery.task
 def run_mtr() -> None:
-    """Run the MTR command and update the global variable with the results."""
+    """Run MTR for all configured targets and store the results."""
     with ThreadPoolExecutor() as executor:
         results = list(executor.map(mtr, app.targets))
 

--- a/latency_monitor/routes.py
+++ b/latency_monitor/routes.py
@@ -1,30 +1,32 @@
+from typing import cast
+
 from flask import Response, jsonify, render_template
 
-from .latency_monitor import app
+from .app_instance import get_app
+
+app = get_app()
+
+
+def _cached_results(prefix: str) -> dict[str, str]:
+    """Read cached command output for every configured target."""
+    values = cast(
+        list[bytes | None],
+        app.redis.mget([f"{prefix}_{target}" for target in app.targets]),
+    )
+    return {
+        target: (value.decode("utf-8") if value else "")
+        for target, value in zip(app.targets, values)
+    }
 
 
 @app.flask.route("/")
 def index() -> tuple[str, int]:
-    mtr_results = {
-        target: (res.decode("utf-8") if res else "")
-        for target, res in zip(
-            app.targets, app.redis.mget([f"mtr_{target}" for target in app.targets])
-        )
-    }
-
-    dig_results = {
-        target: (res.decode("utf-8") if res else "")
-        for target, res in zip(
-            app.targets, app.redis.mget([f"dig_{target}" for target in app.targets])
-        )
-    }
-
     return (
         render_template(
             "index.html",
             targets=app.targets,
-            mtr_results=mtr_results,
-            dig_results=dig_results,
+            mtr_results=_cached_results("mtr"),
+            dig_results=_cached_results("dig"),
         ),
         200,
     )
@@ -32,30 +34,16 @@ def index() -> tuple[str, int]:
 
 @app.flask.route("/json")
 def json() -> tuple[Response, int]:
-    mtr_results = {
-        target: (res.decode("utf-8") if res else "")
-        for target, res in zip(
-            app.targets, app.redis.mget([f"mtr_{target}" for target in app.targets])
-        )
-    }
-
-    dig_results = {
-        target: (res.decode("utf-8") if res else "")
-        for target, res in zip(
-            app.targets, app.redis.mget([f"dig_{target}" for target in app.targets])
-        )
-    }
-
     response = {
         "mtr": {
             "targets": app.targets,
             "command": "mtr -rwznc 10 [-6] <target>",
-            "results": mtr_results,
+            "results": _cached_results("mtr"),
         },
         "dig": {
             "targets": app.targets,
             "command": "dig google.com @<target>",
-            "results": dig_results,
+            "results": _cached_results("dig"),
         },
     }
     return jsonify(response), 200

--- a/latency_monitor/routes.py
+++ b/latency_monitor/routes.py
@@ -21,6 +21,7 @@ def _cached_results(prefix: str) -> dict[str, str]:
 
 @app.flask.route("/")
 def index() -> tuple[str, int]:
+    """Render the monitor dashboard with cached MTR and DIG output."""
     return (
         render_template(
             "index.html",
@@ -34,6 +35,7 @@ def index() -> tuple[str, int]:
 
 @app.flask.route("/json")
 def json() -> tuple[Response, int]:
+    """Return cached monitoring results as JSON."""
     response = {
         "mtr": {
             "targets": app.targets,
@@ -51,11 +53,13 @@ def json() -> tuple[Response, int]:
 
 @app.flask.route("/trigger-mtr")
 def trigger_mtr() -> tuple[Response, int]:
+    """Queue an immediate MTR collection task."""
     result = app.celery.send_task("latency_monitor.mtr.run_mtr")
     return jsonify({"task_id": result.id}), 202
 
 
 @app.flask.route("/trigger-dig")
 def trigger_dig() -> tuple[Response, int]:
+    """Queue an immediate DIG collection task."""
     result = app.celery.send_task("latency_monitor.dig.run_dig")
     return jsonify({"task_id": result.id}), 202

--- a/latency_monitor/utils.py
+++ b/latency_monitor/utils.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict, Union
 
 from rich.console import Console
 from rich.panel import Panel
@@ -9,7 +8,7 @@ from rich.text import Text
 console = Console()
 
 
-def parse_mtr(output: str, target_ip: str) -> Dict[str, Union[float, int]]:
+def parse_mtr(output: str, target_ip: str) -> dict[str, float | int]:
     """
     Extracts the latency values, loss percentage,
     and sent packets count for a specific target IP from the MTR output.

--- a/latency_monitor/utils.py
+++ b/latency_monitor/utils.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 
 from rich.console import Console
 from rich.panel import Panel
@@ -6,6 +7,32 @@ from rich.table import Table
 from rich.text import Text
 
 console = Console()
+COMMAND_TIMEOUT_SECONDS = 60
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a monitoring command with a bounded runtime and useful failures."""
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"{command[0]} timed out after {COMMAND_TIMEOUT_SECONDS} seconds"
+        ) from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        detail = f": {stderr}" if stderr else ""
+        raise RuntimeError(
+            f"{command[0]} exited with status {result.returncode}{detail}"
+        )
+
+    return result
 
 
 def parse_mtr(output: str, target_ip: str) -> dict[str, float | int]:
@@ -117,6 +144,14 @@ def print_task_start(task_name: str, target: str) -> None:
     console.print(
         f"[dim]{'─' * 40}[/]\n"
         f"[bold blue]▶[/] Running [cyan]{task_name}[/] for [magenta]{target}[/]"
+    )
+
+
+def print_task_error(task_name: str, target: str, error: str) -> None:
+    """Print a monitoring command failure without aborting other targets."""
+    console.print(
+        f"[bold red]✖[/] [cyan]{task_name}[/] failed for "
+        f"[magenta]{target}[/]: {error}"
     )
 
 

--- a/latency_monitor/utils.py
+++ b/latency_monitor/utils.py
@@ -24,6 +24,8 @@ def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
         raise RuntimeError(
             f"{command[0]} timed out after {COMMAND_TIMEOUT_SECONDS} seconds"
         ) from exc
+    except OSError as exc:
+        raise RuntimeError(f"could not start {command[0]}: {exc}") from exc
 
     if result.returncode != 0:
         stderr = result.stderr.strip()

--- a/tests/test_application_imports.py
+++ b/tests/test_application_imports.py
@@ -45,7 +45,7 @@ assert "latency_monitor.dig.run_dig" in celery.tasks
             "celery",
             "-A",
             "latency_monitor.latency_monitor:celery",
-            "--help",
+            "report",
         ],
         env=environment,
         capture_output=True,

--- a/tests/test_application_imports.py
+++ b/tests/test_application_imports.py
@@ -1,0 +1,81 @@
+import os
+import subprocess
+import sys
+
+TEST_ENVIRONMENT = {
+    "REDIS_HOST": "localhost",
+    "REDIS_PORT": "6379",
+    "TARGETS": "1.1.1.1",
+    "INFLUXDB_V2_URL": "http://localhost:8086",
+    "INFLUXDB_V2_ORG": "test-org",
+    "INFLUXDB_V2_TOKEN": "test-token",
+    "INFLUXDB_BUCKET": "test-bucket",
+}
+
+
+def test_application_import_and_celery_cli_entrypoint():
+    environment = os.environ | TEST_ENVIRONMENT
+    script = """
+from latency_monitor.latency_monitor import app, celery, flask
+from latency_monitor.mtr import app as mtr_app, run_mtr
+from latency_monitor.dig import app as dig_app, run_dig
+
+assert app is mtr_app is dig_app
+assert app.celery is celery
+assert app.flask is flask
+assert run_mtr.name == "latency_monitor.mtr.run_mtr"
+assert run_dig.name == "latency_monitor.dig.run_dig"
+assert "latency_monitor.mtr.run_mtr" in celery.tasks
+assert "latency_monitor.dig.run_dig" in celery.tasks
+"""
+
+    import_result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert import_result.returncode == 0, import_result.stderr
+
+    cli_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "celery",
+            "-A",
+            "latency_monitor.latency_monitor:celery",
+            "--help",
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert cli_result.returncode == 0, cli_result.stderr
+
+
+def test_importing_task_module_first_uses_initialized_application():
+    environment = os.environ | TEST_ENVIRONMENT
+    script = """
+from latency_monitor.mtr import app as mtr_app
+from latency_monitor.app_instance import get_app
+from latency_monitor.latency_monitor import app
+from latency_monitor.routes import app as routes_app
+
+assert app is mtr_app is routes_app is get_app()
+assert "latency_monitor.mtr.run_mtr" in app.celery.tasks
+assert "latency_monitor.dig.run_dig" in app.celery.tasks
+assert {"/", "/json", "/trigger-mtr", "/trigger-dig"} <= {
+    rule.rule for rule in app.flask.url_map.iter_rules()
+}
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,6 @@
-import pytest
 from unittest.mock import MagicMock, patch
-import json
-import sys
+
+import pytest
 
 
 @pytest.fixture
@@ -14,92 +13,100 @@ def client(monkeypatch):
     monkeypatch.setenv("INFLUXDB_V2_TOKEN", "test-token")
     monkeypatch.setenv("INFLUXDB_BUCKET", "test-bucket")
 
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("latency_monitor"):
-            del sys.modules[mod]
-
-    mock_redis_instance = MagicMock()
-    mock_influx_instance = MagicMock()
+    mock_redis = MagicMock()
+    mock_influx = MagicMock()
+    mock_write_api = MagicMock()
     mock_celery = MagicMock()
 
-    with patch("redis.Redis", return_value=mock_redis_instance):
-        with patch("influxdb_client.InfluxDBClient.from_env_properties", return_value=mock_influx_instance):
-            from latency_monitor.latency_monitor import app
+    with patch("redis.Redis", return_value=mock_redis), patch(
+        "influxdb_client.InfluxDBClient.from_env_properties",
+        return_value=mock_influx,
+    ):
+        mock_influx.write_api.return_value = mock_write_api
+        from latency_monitor.latency_monitor import app
 
-            app.redis = mock_redis_instance
-            app.celery = mock_celery
+        app.redis = mock_redis
+        app.influx = mock_influx
+        app.influx_write_api = mock_write_api
+        app.celery = mock_celery
+        app.targets = ["8.8.8.8", "1.1.1.1"]
 
-            with app.flask.test_client() as test_client:
-                yield test_client, app, mock_redis_instance, mock_celery
+        with app.flask.test_client() as test_client:
+            yield test_client, mock_redis, mock_celery
 
 
 class TestRoutes:
     def test_index_returns_html(self, client):
-        test_client, app, mock_redis, _ = client
-        mock_redis.mget.return_value = [b"mtr output", b"mtr output 2"]
+        test_client, mock_redis, _ = client
+        mock_redis.mget.side_effect = [
+            [b"mtr output", b"mtr output 2"],
+            [b"dig output", b"dig output 2"],
+        ]
 
         response = test_client.get("/")
 
         assert response.status_code == 200
-        assert b"<!DOCTYPE html>" in response.data or b"<html" in response.data
+        assert b"<!DOCTYPE html>" in response.data
 
     def test_index_with_empty_redis(self, client):
-        test_client, app, mock_redis, _ = client
-        mock_redis.mget.return_value = [None, None]
+        test_client, mock_redis, _ = client
+        mock_redis.mget.side_effect = [[None, None], [None, None]]
 
         response = test_client.get("/")
 
         assert response.status_code == 200
 
     def test_json_endpoint(self, client):
-        test_client, app, mock_redis, _ = client
-        mock_redis.mget.return_value = [b"mtr result 1", b"mtr result 2"]
+        test_client, mock_redis, _ = client
+        mock_redis.mget.side_effect = [
+            [b"mtr output", b"mtr output 2"],
+            [b"dig output", b"dig output 2"],
+        ]
 
         response = test_client.get("/json")
 
         assert response.status_code == 200
-        data = json.loads(response.data)
-        assert "mtr" in data
-        assert "dig" in data
-        assert "targets" in data["mtr"]
-        assert "results" in data["mtr"]
-        assert "command" in data["mtr"]
+        assert response.json["mtr"]["targets"] == ["8.8.8.8", "1.1.1.1"]
+        assert response.json["mtr"]["results"] == {
+            "8.8.8.8": "mtr output",
+            "1.1.1.1": "mtr output 2",
+        }
+        assert response.json["dig"]["results"] == {
+            "8.8.8.8": "dig output",
+            "1.1.1.1": "dig output 2",
+        }
 
     def test_json_endpoint_structure(self, client):
-        test_client, app, mock_redis, _ = client
-        app.targets = ["8.8.8.8", "1.1.1.1"]
-        mock_redis.mget.return_value = [b"output1", b"output2"]
+        test_client, mock_redis, _ = client
+        mock_redis.mget.side_effect = [[b"mtr output", b"mtr output 2"], [None, None]]
 
         response = test_client.get("/json")
 
-        data = json.loads(response.data)
-        assert data["mtr"]["targets"] == ["8.8.8.8", "1.1.1.1"]
-        assert data["dig"]["targets"] == ["8.8.8.8", "1.1.1.1"]
-        assert data["mtr"]["command"] == "mtr -rwznc 10 [-6] <target>"
-        assert data["dig"]["command"] == "dig google.com @<target>"
+        assert response.status_code == 200
+        assert set(response.json) == {"mtr", "dig"}
+        assert response.json["mtr"]["command"] == "mtr -rwznc 10 [-6] <target>"
+        assert response.json["dig"]["command"] == "dig google.com @<target>"
+        assert response.json["dig"]["results"] == {
+            "8.8.8.8": "",
+            "1.1.1.1": "",
+        }
 
     def test_trigger_mtr(self, client):
-        test_client, app, mock_redis, mock_celery = client
-        mock_result = MagicMock()
-        mock_result.id = "test-task-id-123"
-        mock_celery.send_task.return_value = mock_result
+        test_client, _, mock_celery = client
+        mock_celery.send_task.return_value.id = "test-task-id-123"
 
         response = test_client.get("/trigger-mtr")
 
         assert response.status_code == 202
-        data = json.loads(response.data)
-        assert data["task_id"] == "test-task-id-123"
+        assert response.json == {"task_id": "test-task-id-123"}
         mock_celery.send_task.assert_called_once_with("latency_monitor.mtr.run_mtr")
 
     def test_trigger_dig(self, client):
-        test_client, app, mock_redis, mock_celery = client
-        mock_result = MagicMock()
-        mock_result.id = "test-task-id-456"
-        mock_celery.send_task.return_value = mock_result
+        test_client, _, mock_celery = client
+        mock_celery.send_task.return_value.id = "test-task-id-456"
 
         response = test_client.get("/trigger-dig")
 
         assert response.status_code == 202
-        data = json.loads(response.data)
-        assert data["task_id"] == "test-task-id-456"
+        assert response.json == {"task_id": "test-task-id-456"}
         mock_celery.send_task.assert_called_once_with("latency_monitor.dig.run_dig")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,6 +19,10 @@ def client(monkeypatch):
     mock_write_api = MagicMock()
     mock_celery = MagicMock()
 
+    for module_name in list(sys.modules):
+        if module_name.startswith("latency_monitor"):
+            del sys.modules[module_name]
+
     with patch("redis.Redis", return_value=mock_redis), patch(
         "influxdb_client.InfluxDBClient.from_env_properties",
         return_value=mock_influx,
@@ -25,14 +30,18 @@ def client(monkeypatch):
         mock_influx.write_api.return_value = mock_write_api
         from latency_monitor.latency_monitor import app
 
-        app.redis = mock_redis
-        app.influx = mock_influx
-        app.influx_write_api = mock_write_api
-        app.celery = mock_celery
-        app.targets = ["8.8.8.8", "1.1.1.1"]
+        monkeypatch.setattr(app, "redis", mock_redis)
+        monkeypatch.setattr(app, "influx", mock_influx)
+        monkeypatch.setattr(app, "influx_write_api", mock_write_api)
+        monkeypatch.setattr(app, "celery", mock_celery)
+        monkeypatch.setattr(app, "targets", ["8.8.8.8", "1.1.1.1"])
 
         with app.flask.test_client() as test_client:
             yield test_client, mock_redis, mock_celery
+
+    for module_name in list(sys.modules):
+        if module_name.startswith("latency_monitor"):
+            del sys.modules[module_name]
 
 
 class TestRoutes:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -123,6 +123,31 @@ class TestRunMtrTask:
         )
         mock_app.influx_write_api.write.assert_not_called()
 
+    def test_run_mtr_task_keeps_successful_target_after_parse_failure(self, mock_app):
+        mock_app.targets = ["8.8.8.8", "1.1.1.1"]
+
+        def command_result(command, **_kwargs):
+            target = command[-1]
+            if target == "8.8.8.8":
+                return MagicMock(stdout="malformed output", stderr="", returncode=0)
+            return MagicMock(
+                stdout="""HOST: server                      Loss%   Snt   Last   Avg  Best  Wrst StDev
+  1.|-- 1.1.1.1                   0.0%    10   10.5  11.2   9.8  15.3   1.5""",
+                stderr="",
+                returncode=0,
+            )
+
+        with patch("subprocess.run", side_effect=command_result):
+            from latency_monitor.mtr import run_mtr
+
+            run_mtr()
+
+        assert mock_app.redis.set.call_count == 2
+        mock_app.redis.set.assert_any_call(
+            "mtr_8.8.8.8", "ERROR: Target IP 8.8.8.8 not found in MTR output."
+        )
+        mock_app.influx_write_api.write.assert_called_once()
+
 
 class TestDigFunction:
     def test_dig_function(self, mock_app):
@@ -194,5 +219,27 @@ class TestRunDigTask:
         mock_app.redis.set.assert_any_call(
             "dig_8.8.8.8", "ERROR: dig exited with status 9: network unreachable"
         )
+        mock_app.redis.set.assert_any_call("dig_1.1.1.1", ";; Query time: 15 msec")
+        mock_app.influx_write_api.write.assert_called_once()
+
+    def test_run_dig_task_keeps_successful_target_after_launch_failure(self, mock_app):
+        mock_app.targets = ["8.8.8.8", "1.1.1.1"]
+
+        def command_result(command, **_kwargs):
+            target = command[-1]
+            if target == "@8.8.8.8":
+                raise FileNotFoundError(2, "No such file or directory", "dig")
+            return MagicMock(
+                stdout=";; Query time: 15 msec", stderr="", returncode=0
+            )
+
+        with patch("subprocess.run", side_effect=command_result):
+            from latency_monitor.dig import run_dig
+
+            run_dig()
+
+        assert mock_app.redis.set.call_count == 2
+        launch_error = mock_app.redis.set.call_args_list[0].args[1]
+        assert launch_error.startswith("ERROR: could not start dig:")
         mock_app.redis.set.assert_any_call("dig_1.1.1.1", ";; Query time: 15 msec")
         mock_app.influx_write_api.write.assert_called_once()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,7 @@
-import pytest
-from unittest.mock import MagicMock, patch
 import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 @pytest.fixture
@@ -22,16 +23,18 @@ def mock_app(monkeypatch):
     mock_write_api = MagicMock()
     mock_influx_instance.write_api.return_value = mock_write_api
 
-    with patch("redis.Redis", return_value=mock_redis_instance):
-        with patch("influxdb_client.InfluxDBClient.from_env_properties", return_value=mock_influx_instance):
-            from latency_monitor.latency_monitor import app
+    with patch("redis.Redis", return_value=mock_redis_instance), patch(
+        "influxdb_client.InfluxDBClient.from_env_properties",
+        return_value=mock_influx_instance,
+    ):
+        from latency_monitor.latency_monitor import app
 
-            app.redis = mock_redis_instance
-            app.influx = mock_influx_instance
-            app.influx_write_api = mock_write_api
-            app.targets = ["8.8.8.8"]
+        app.redis = mock_redis_instance
+        app.influx = mock_influx_instance
+        app.influx_write_api = mock_write_api
+        app.targets = ["8.8.8.8"]
 
-            yield app
+        yield app
 
 
 class TestMtrFunction:
@@ -50,7 +53,8 @@ class TestMtrFunction:
             mock_run.assert_called_once_with(
                 ["mtr", "-rwznc", "10", "8.8.8.8"],
                 capture_output=True,
-                text=True
+                text=True,
+                check=False,
             )
             assert result["target"] == "8.8.8.8"
             assert result["stdout"] == mtr_output
@@ -71,7 +75,8 @@ class TestMtrFunction:
             mock_run.assert_called_once_with(
                 ["mtr", "-rwznc", "10", "-6", "2001:4860:4860::8888"],
                 capture_output=True,
-                text=True
+                text=True,
+                check=False,
             )
             assert result["target"] == "2001:4860:4860::8888"
 
@@ -112,7 +117,8 @@ class TestDigFunction:
             mock_run.assert_called_once_with(
                 ["dig", "google.com", "@8.8.8.8"],
                 capture_output=True,
-                text=True
+                text=True,
+                check=False,
             )
             assert result["target"] == "8.8.8.8"
             assert result["stdout"] == dig_output

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -44,6 +44,8 @@ class TestMtrFunction:
 
         mock_result = MagicMock()
         mock_result.stdout = mtr_output
+        mock_result.returncode = 0
+        mock_result.stderr = ""
 
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             from latency_monitor.mtr import mtr
@@ -55,6 +57,7 @@ class TestMtrFunction:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=60,
             )
             assert result["target"] == "8.8.8.8"
             assert result["stdout"] == mtr_output
@@ -66,6 +69,8 @@ class TestMtrFunction:
 
         mock_result = MagicMock()
         mock_result.stdout = mtr_output
+        mock_result.returncode = 0
+        mock_result.stderr = ""
 
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             from latency_monitor.mtr import mtr
@@ -77,6 +82,7 @@ class TestMtrFunction:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=60,
             )
             assert result["target"] == "2001:4860:4860::8888"
 
@@ -88,6 +94,8 @@ class TestRunMtrTask:
 
         mock_result = MagicMock()
         mock_result.stdout = mtr_output
+        mock_result.returncode = 0
+        mock_result.stderr = ""
 
         with patch("subprocess.run", return_value=mock_result):
             from latency_monitor.mtr import run_mtr
@@ -100,6 +108,21 @@ class TestRunMtrTask:
 
             mock_app.influx_write_api.write.assert_called_once()
 
+    def test_run_mtr_task_caches_failure_without_writing_metric(self, mock_app):
+        mock_result = MagicMock(
+            stdout="", stderr="mtr: permission denied", returncode=1
+        )
+
+        with patch("subprocess.run", return_value=mock_result):
+            from latency_monitor.mtr import run_mtr
+
+            run_mtr()
+
+        mock_app.redis.set.assert_called_once_with(
+            "mtr_8.8.8.8", "ERROR: mtr exited with status 1: mtr: permission denied"
+        )
+        mock_app.influx_write_api.write.assert_not_called()
+
 
 class TestDigFunction:
     def test_dig_function(self, mock_app):
@@ -108,6 +131,8 @@ class TestDigFunction:
 
         mock_result = MagicMock()
         mock_result.stdout = dig_output
+        mock_result.returncode = 0
+        mock_result.stderr = ""
 
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             from latency_monitor.dig import dig
@@ -119,6 +144,7 @@ class TestDigFunction:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=60,
             )
             assert result["target"] == "8.8.8.8"
             assert result["stdout"] == dig_output
@@ -132,6 +158,8 @@ class TestRunDigTask:
 
         mock_result = MagicMock()
         mock_result.stdout = dig_output
+        mock_result.returncode = 0
+        mock_result.stderr = ""
 
         with patch("subprocess.run", return_value=mock_result):
             from latency_monitor.dig import run_dig
@@ -143,3 +171,28 @@ class TestRunDigTask:
             assert call_args[0][0] == "dig_8.8.8.8"
 
             mock_app.influx_write_api.write.assert_called_once()
+
+    def test_run_dig_task_keeps_successful_targets_when_one_fails(self, mock_app):
+        mock_app.targets = ["8.8.8.8", "1.1.1.1"]
+
+        def command_result(command, **_kwargs):
+            target = command[-1]
+            if target == "@8.8.8.8":
+                return MagicMock(
+                    stdout="", stderr="network unreachable", returncode=9
+                )
+            return MagicMock(
+                stdout=";; Query time: 15 msec", stderr="", returncode=0
+            )
+
+        with patch("subprocess.run", side_effect=command_result):
+            from latency_monitor.dig import run_dig
+
+            run_dig()
+
+        assert mock_app.redis.set.call_count == 2
+        mock_app.redis.set.assert_any_call(
+            "dig_8.8.8.8", "ERROR: dig exited with status 9: network unreachable"
+        )
+        mock_app.redis.set.assert_any_call("dig_1.1.1.1", ";; Query time: 15 msec")
+        mock_app.influx_write_api.write.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,47 @@
+import subprocess
+from unittest.mock import patch
+
 import pytest
 
-from latency_monitor.utils import parse_dig, parse_mtr
+from latency_monitor.utils import (
+    COMMAND_TIMEOUT_SECONDS,
+    parse_dig,
+    parse_mtr,
+    run_command,
+)
+
+
+class TestRunCommand:
+    def test_run_command_passes_timeout_and_returns_success(self):
+        completed = subprocess.CompletedProcess(["dig"], 0, "output", "")
+
+        with patch("subprocess.run", return_value=completed) as run:
+            result = run_command(["dig", "google.com"])
+
+        run.assert_called_once_with(
+            ["dig", "google.com"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+        assert result is completed
+
+    def test_run_command_reports_nonzero_exit_with_stderr(self):
+        completed = subprocess.CompletedProcess(["mtr"], 2, "", "permission denied")
+
+        with patch("subprocess.run", return_value=completed), pytest.raises(
+            RuntimeError, match="mtr exited with status 2: permission denied"
+        ):
+            run_command(["mtr", "example.com"])
+
+    def test_run_command_reports_timeout(self):
+        timeout = subprocess.TimeoutExpired(["dig"], COMMAND_TIMEOUT_SECONDS)
+
+        with patch("subprocess.run", side_effect=timeout), pytest.raises(
+            RuntimeError, match="dig timed out after 60 seconds"
+        ):
+            run_command(["dig", "google.com"])
 
 
 class TestParseMtr:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,14 @@ class TestRunCommand:
         ):
             run_command(["dig", "google.com"])
 
+    def test_run_command_reports_process_start_failure(self):
+        failure = FileNotFoundError(2, "No such file or directory", "dig")
+
+        with patch("subprocess.run", side_effect=failure), pytest.raises(
+            RuntimeError, match="could not start dig"
+        ):
+            run_command(["dig", "google.com"])
+
 
 class TestParseMtr:
     def test_parse_mtr_valid_output(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from latency_monitor.utils import parse_mtr, parse_dig
+from latency_monitor.utils import parse_dig, parse_mtr
 
 
 class TestParseMtr:


### PR DESCRIPTION
## Summary

- Repair the shared Flask/Celery application lifecycle and task registration.
- Restore MTR task behavior and fix route/API tests.
- Align local development and Docker Compose commands with uv and the current Celery entrypoint.
- Keep the lockfile consistent with the existing `rich` dependency.

## Verification

- `uv run pytest` — 21 passed
- `uv run --with ruff ruff check latency_monitor tests` — passed
- `uv lock --check` — passed
- `uv build` — passed
- `docker compose config --quiet` — passed
- Celery import/task-registration smoke test — passed

## Security update sequencing

The Renovate security PRs are intentionally separate and will be handled after this PR is merged:

- #289 — Flask 3.1.3
- #290 — pytest security update

No dependency-alert claims are made by this application PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the Flask/Celery app lifecycle and isolates per-target failures so scheduled MTR/DIG runs are reliable and the API/UI remain stable. Previously modules could initialize separate apps and one failing command could break a run; now tasks and routes share one `App`, and failures cache an error string without blocking other targets.

- Centralizes config in `App` and shares it via `app_instance.get_app()/set_app()`. Routes and tasks register after the singleton is set; the `celery` CLI entrypoint `latency_monitor.latency_monitor:celery` works regardless of import order; periodic `run_mtr`/`run_dig` schedules are active.
- Adds `utils.run_command` with a 60s timeout and readable errors; `mtr`/`dig` use it. On non‑zero exit/timeout/start errors, Redis stores “ERROR: …” and Influx writes are skipped for that target.
- Provides defaults for `REDIS_HOST`, `REDIS_PORT`, and `TARGETS`. Unifies result reads with a helper for `/` and `/json`, which handle empty caches cleanly.
- Switches dev and Docker commands to `uv`; fixes worker entrypoint to `latency_monitor.latency_monitor:celery`.

**Required changes**
- In Docker Compose, set worker to: `uv run celery -A latency_monitor.latency_monitor:celery worker -B --loglevel=info`.
- Use `uv` locally: `uv sync`, `uv run python -m latency_monitor.latency_monitor`, `uv run celery -A latency_monitor.latency_monitor:celery …`, `uv run pytest`.

<sup>Written for commit 490f09d06854e7022c53ce39b7014cf41ae3133e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TurboCheetah/latency-monitor/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development instructions with `uv` commands for setup, running services, and tests.
* **Improvements**
  * Improved application startup and configuration when optional environment settings are not provided.
  * Added sensible default connection and monitoring target settings.
  * Improved handling of monitoring command failures so results can still be processed.
  * Standardized result retrieval across web pages and JSON endpoints.
* **Bug Fixes**
  * Improved consistency of empty and completed monitoring results returned by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->