### PR TITLE
fix: keep major Renovate security updates manual

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,21 +27,6 @@
         "major"
       ],
       "automerge": false
-    },
-    {
-      "matchJsonata": [
-        "isVulnerabilityAlert = true"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "addLabels": [
-        "security"
-      ],
-      "automerge": true
     }
   ],
   "osvVulnerabilityAlerts": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,7 +30,13 @@
     },
     {
       "matchJsonata": [
-        "$exists(vulnerabilityFixVersion)"
+        "isVulnerabilityAlert = true"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
       ],
       "addLabels": [
         "security"
@@ -43,7 +49,6 @@
     "addLabels": [
       "security"
     ],
-    "automerge": true,
     "vulnerabilityFixStrategy": "lowest"
   }
 }


### PR DESCRIPTION
## Summary

- automerges minor, patch, pin, and digest vulnerability fixes after checks pass
- keeps vulnerability fixes requiring a major upgrade manual
- applies the policy to both GitHub vulnerability alerts and supplemental OSV findings
- retains the dependency label, adds `security`, and selects the lowest patched version

This follows the review-bot finding confirmed against Renovate 44.26.0 source: generated GitHub and OSV vulnerability rules both set `isVulnerabilityAlert: true`, while `vulnerabilityAlerts` is applied as forced configuration. Keeping `automerge` out of that forced object permits update-type-specific policy.

## Validation

- Renovate 44.26.0 configuration validator
- exact remote config read-back


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved vulnerability alert detection for dependency updates.
  * Disabled automatic merging for vulnerability-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps major Renovate security updates manual and removes forced automerge on vulnerability alerts so update-type rules apply. Previously, vulnerability alerts auto-merged; now majors require manual review and non-majors follow the existing automerge policy.

**Review notes**
- Removes the package rule matching `vulnerabilityFixVersion` that auto-merged all security updates.
- Drops `automerge` from the forced `vulnerabilityAlerts` config; retains `addLabels: ["security"]` and `vulnerabilityFixStrategy: "lowest"`.
- Applies to both GitHub and OSV alerts (`osvVulnerabilityAlerts: true`).

<sup>Written for commit 0b508c40593f379352ca21cd380014aba5f592d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TurboCheetah/latency-monitor/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

